### PR TITLE
Fix resume task argument build and improve robocopy return

### DIFF
--- a/PCSwapTool_v0.5.20.ps1
+++ b/PCSwapTool_v0.5.20.ps1
@@ -921,9 +921,10 @@ function Register-UserResumeTaskEx {
     )
     try {
         $taskName = 'PCSwap-Resume-User'
-        # Base args always include -ResumeUser
-        $args = "-NoProfile -ExecutionPolicy Bypass -File `\"$ScriptPath\"` -ResumeUser"
-        if ($ManifestPath) { $args += " -Manifest `\"$ManifestPath\"`" }
+        # Build the argument list as an array to avoid quoting issues
+        $argList = @('-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', "`"$ScriptPath`"", '-ResumeUser')
+        if ($ManifestPath) { $argList += @('-Manifest', "`"$ManifestPath`"") }
+        $args    = $argList -join ' '
         $action  = New-ScheduledTaskAction -Execute 'powershell.exe' -Argument $args
         $trigger = New-ScheduledTaskTrigger -AtLogOn -User $UserName
         $principal = New-ScheduledTaskPrincipal -UserId $UserName -RunLevel Limited -LogonType Interactive
@@ -945,8 +946,9 @@ function Copy-ProfileToUser { param([string]$SourceFolder,[string]$TargetUserNam
     $args=@($SourceFolder,$targetProfile,"/E","/R:1","/W:1","/XJ") + $copyFlags + $xdArgs
     Write-Log -Message "Restoring files: $SourceFolder -> $targetProfile Flags=$($copyFlags -join ' ')"
     $proc=Start-Process -FilePath robocopy.exe -ArgumentList $args -Wait -PassThru -NoNewWindow
-    $code=$proc.ExitCode; Write-Log -Message "Robocopy restore exit code: $code"
-    "Robocopy restore exit code: $code (0/1=OK)."
+    $code=$proc.ExitCode
+    Write-Log -Message "Robocopy restore exit code: $code"
+    return "Robocopy restore exit code: $code (0/1=OK)."
 }
 
 # ------------------- GUI -----------------------


### PR DESCRIPTION
## Summary
- Fix Register-UserResumeTaskEx to construct argument list properly and include manifest path
- Clean up Copy-ProfileToUser to log and return robocopy exit code clearly

## Testing
- ⚠️ `pwsh -NoLogo -NoProfile -Command "Get-Date"` (PowerShell not installed; package unavailable)


------
https://chatgpt.com/codex/tasks/task_e_68ab90fa37fc832aba571fc2ab8cb3bd