### PR TITLE
Fix scheduled task argument quoting

### DIFF
--- a/PCSwapTool_v0.5.20.ps1
+++ b/PCSwapTool_v0.5.20.ps1
@@ -922,8 +922,8 @@ function Register-UserResumeTaskEx {
     try {
         $taskName = 'PCSwap-Resume-User'
         # Base args always include -ResumeUser
-        $args = "-NoProfile -ExecutionPolicy Bypass -File `\"$ScriptPath\"` -ResumeUser"
-        if ($ManifestPath) { $args += " -Manifest `\"$ManifestPath\"`" }
+        $args = "-NoProfile -ExecutionPolicy Bypass -File `"$ScriptPath`" -ResumeUser"
+        if ($ManifestPath) { $args += " -Manifest `"$ManifestPath`"" }
         $action  = New-ScheduledTaskAction -Execute 'powershell.exe' -Argument $args
         $trigger = New-ScheduledTaskTrigger -AtLogOn -User $UserName
         $principal = New-ScheduledTaskPrincipal -UserId $UserName -RunLevel Limited -LogonType Interactive


### PR DESCRIPTION
## Summary
- fix the resume scheduled task command string to use proper PowerShell quoting so the script parses correctly when -Manifest is provided

## Testing
- pwsh -NoLogo -Command '$tokens = $null; $errors = $null; [void][System.Management.Automation.Language.Parser]::ParseFile("PCSwapTool_v0.5.20.ps1",[ref]$tokens,[ref]$errors); if($errors){$errors.Count}else{0}'

------
https://chatgpt.com/codex/tasks/task_e_68d5799dda8c832aaebddff23ea48032