### PR TITLE
Fix default app association XML quoting

### DIFF
--- a/PCSwapTool_v0.5.20.ps1
+++ b/PCSwapTool_v0.5.20.ps1
@@ -861,11 +861,11 @@ function Apply-SystemDefaultAppsFromManifest { param($Manifest)
             return
         }
         if ($pdfProgId) {
-            $associations += "  <Association Identifier=\".pdf\" ProgId=\"$pdfProgId\" ApplicationName=\"PDF\" />"
+            $associations += "  <Association Identifier=`".pdf`" ProgId=`"$pdfProgId`" ApplicationName=`"PDF`" />"
         }
         if ($browserProgId) {
-            $associations += "  <Association Identifier=\"http\" ProgId=\"$browserProgId\" ApplicationName=\"Browser\" />"
-            $associations += "  <Association Identifier=\"https\" ProgId=\"$browserProgId\" ApplicationName=\"Browser\" />"
+            $associations += "  <Association Identifier=`"http`" ProgId=`"$browserProgId`" ApplicationName=`"Browser`" />"
+            $associations += "  <Association Identifier=`"https`" ProgId=`"$browserProgId`" ApplicationName=`"Browser`" />"
         }
         $targetRoot = $SwapInfoRoot
         if (-not $targetRoot) {


### PR DESCRIPTION
## Summary
- escape double quotes in the default application association XML snippets so the script parses correctly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7e80af57c832a8199d333c597a118