### PR TITLE
Handle WScript.Network Count method during mapped drive enumeration

### DIFF
--- a/PCSwapTool_v0.5.20.ps1
+++ b/PCSwapTool_v0.5.20.ps1
@@ -299,14 +299,18 @@ function Get-MappedDrives {
     try {
         $ws = New-Object -ComObject WScript.Network
         $col = $ws.EnumNetworkDrives()
-        for ($i = 0; $i -lt $col.Count; $i += 2) {
-            $drv  = $col.Item($i)
-            $path = $col.Item($i + 1)
-            if (-not [string]::IsNullOrWhiteSpace($drv)) {
-                $drives += [PSCustomObject]@{
-                    DeviceID     = $drv
-                    ProviderName = $path
-                    VolumeName   = $null
+        if ($null -ne $col) {
+            $countMethod = $col.PSObject.Methods['Count']
+            $count = if ($countMethod) { [int]$col.Count() } else { 0 }
+            for ($i = 0; $i -lt $count; $i += 2) {
+                $drv  = $col.Item($i)
+                $path = $col.Item($i + 1)
+                if (-not [string]::IsNullOrWhiteSpace($drv)) {
+                    $drives += [PSCustomObject]@{
+                        DeviceID     = $drv
+                        ProviderName = $path
+                        VolumeName   = $null
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- guard the WScript.Network EnumNetworkDrives collection before iteration
- call the Count() method explicitly so strict mode no longer sees a PSMethod value during comparisons

## Testing
- not run (PowerShell-specific tooling not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d7e94b80e4832a84b4d008536e8842