### PR TITLE
Expand installed program list in technician report

### DIFF
--- a/PCSwapTool_v0.5.20.ps1
+++ b/PCSwapTool_v0.5.20.ps1
@@ -742,8 +742,8 @@ function Write-Report { param($Manifest,$CopySummary)
     $L += "---- Printers ----"
     foreach($p in $Manifest.Computer.Printers){ $L += "$($p.Name) | Driver: $($p.DriverName) | Port: $($p.PortName)" }
     $L += ""
-    $L += "---- Installed Programs (top 50 by name) ----"
-    foreach($app in ($Manifest.Computer.InstalledPrograms | Sort-Object Name | Select-Object -First 50)){ $L += "$($app.Name) | Version: $($app.Version) | Installed: $($app.InstallDate) | Dir: $($app.InstallDir)" }
+    $L += "---- Installed Programs ----"
+    foreach($app in ($Manifest.Computer.InstalledPrograms | Sort-Object Name)){ $L += "$($app.Name) | Version: $($app.Version) | Installed: $($app.InstallDate) | Dir: $($app.InstallDir)" }
     $L += ""
     # Wireless networks
     if ($Manifest.Computer.WirelessNetworks -and $Manifest.Computer.WirelessNetworks.Count -gt 0) {


### PR DESCRIPTION
## Summary
- remove the top-50 limit from the technician report's installed programs section
- adjust the section header to reflect the full inventory capture

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7ea621960832a9ec667d0dbcc71e3