### PR TITLE
Handle new Chrome secret formats

### DIFF
--- a/PCSwapTool_v0.5.20.ps1
+++ b/PCSwapTool_v0.5.20.ps1
@@ -2,7 +2,7 @@
 <# 
     .SYNOPSIS
     PC Swap Tool (GUI) - Gather & Restore
-    Version: 0.5.22 (2025-09-27)
+    Version: 0.5.23 (2025-09-27)
 
 
 .DESCRIPTION
@@ -11,6 +11,12 @@
     to a replacement machine. Native Windows only.
 
 .CHANGELOG
+    0.5.23
+      - Fix: Treat Chrome secrets with any "vXX" prefix as AES-GCM so newer Chrome
+        builds decrypt correctly instead of falling back to DPAPI and failing.
+      - Fix: Retry DPAPI secrets with the LocalMachine scope when CurrentUser
+        decryption is unavailable, covering service and system profiles.
+      - Date: 2025-09-27
     0.5.22
       - Change: Skip creating the Chrome password CSV when no credentials can be
         decrypted and remove any stale export so manifests remain accurate.
@@ -176,7 +182,7 @@ Set-StrictMode -Version Latest
 [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 
 # ------------------------------- Globals -------------------------------------
-$ProgramVersion = '0.5.22'
+$ProgramVersion = '0.5.23'
 $TodayStamp     = Get-Date -Format 'yyyy-MM-dd_HH-mm-ss'
 $Desktop        = [Environment]::GetFolderPath('Desktop')
 $SwapInfoRoot   = $null
@@ -906,7 +912,7 @@ function ConvertFrom-ChromeSecret {
     $prefix = if ($Data.Length -ge 3) { [System.Text.Encoding]::ASCII.GetString($Data, 0, 3) } else { '' }
 
     try {
-        if ($prefix -in @('v10','v11','v12')) {
+        if ($prefix -and ($prefix -match '^v\d{2}$')) {
             if (-not $Key -or $Key.Length -eq 0) {
                 return ''
             }
@@ -942,11 +948,28 @@ function ConvertFrom-ChromeSecret {
         if (-not (Ensure-ProtectedDataSupport)) {
             return ''
         }
-        $dpapiBytes = [System.Security.Cryptography.ProtectedData]::Unprotect(
-            $Data,
-            $null,
-            [System.Security.Cryptography.DataProtectionScope]::CurrentUser
-        )
+
+        $dpapiBytes = $null
+        $lastError = $null
+        foreach ($scope in @([System.Security.Cryptography.DataProtectionScope]::CurrentUser, [System.Security.Cryptography.DataProtectionScope]::LocalMachine)) {
+            try {
+                $dpapiBytes = [System.Security.Cryptography.ProtectedData]::Unprotect(
+                    $Data,
+                    $null,
+                    $scope
+                )
+                $lastError = $null
+                break
+            } catch {
+                $lastError = $_
+                $dpapiBytes = $null
+            }
+        }
+
+        if ($null -eq $dpapiBytes) {
+            if ($lastError) { throw $lastError }
+            return ''
+        }
         return ([System.Text.Encoding]::UTF8.GetString($dpapiBytes)).TrimEnd([char]0)
     } catch {
         Write-Log -Message ("Failed to decrypt Chrome secret: {0}" -f $_) -Level 'WARN'


### PR DESCRIPTION
## Summary
- Gather: treat Chrome password blobs with any `vXX` prefix as AES-GCM so the exporter stays compatible with newer Chrome releases.
- Gather: retry DPAPI secrets with the LocalMachine scope when the CurrentUser scope is unavailable to avoid `CryptUnprotectData` failures on service profiles.

## Testing
- Not run (PowerShell 5.1 environment required)


------
https://chatgpt.com/codex/tasks/task_e_68d80a107cac832a99f51c8a6cc2b863