### PR TITLE
Add Chrome password CSV validation after manual prompt

### DIFF
--- a/PCSwapTool_v0.5.20.ps1
+++ b/PCSwapTool_v0.5.20.ps1
@@ -805,6 +805,17 @@ If Chrome is not installed or has no saved passwords, note that outcome in the t
     Write-Log -Message 'Displayed manual Chrome password export instructions.'
     [System.Windows.Forms.MessageBox]::Show($instructions, 'Chrome Password Export', 'OK', 'Information') | Out-Null
 
+    if ($repoRoot) {
+        $chromeCsvPath = Join-Path $repoRoot $ChromeCsvName
+        if (Test-Path $chromeCsvPath) {
+            Write-Log -Message "Validated presence of manual Chrome password export: $chromeCsvPath" -Level 'INFO'
+        } else {
+            Write-Log -Message "Chrome password CSV not found at expected path after technician acknowledged instructions: $chromeCsvPath" -Level 'WARN'
+        }
+    } else {
+        Write-Log -Message 'Skipping Chrome password CSV validation because SwapInfoRoot is not set.' -Level 'WARN'
+    }
+
     return $true
 }
 


### PR DESCRIPTION
## Summary
- add a validation step after the manual Chrome export instructions close to confirm the CSV exists
- log an informational message when the CSV is present and warn when it is missing or the repository root is unavailable

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d81a17d984832ab2508d5f0cd9e7f1